### PR TITLE
Public Interface class

### DIFF
--- a/AutoTrashInterface.cs
+++ b/AutoTrashInterface.cs
@@ -1,0 +1,28 @@
+﻿
+using Terraria;
+
+
+namespace AutoTrash
+{
+    static public class AutoTrashInterface
+    {
+        static public bool isItemAutoTrashedByPlayer(Player player, int item_type)
+        {
+            // Returns False if AutoTrash is disabled
+            // Returns False if item is not 'AutoTrashed'
+            // Returns True if item is 'AutoTrashed'
+            var mod_player = player.GetModPlayer<AutoTrashPlayer>();
+
+            if (!mod_player.AutoTrashEnabled)
+                return false;
+
+            foreach (var item in mod_player.AutoTrashItems)
+            {
+                if (item_type == item.type)
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
  My goal was to force fished item to go to trash if it is _AutoTrashed_. At this point I only can FishingRod not to catch _AutoTrashed_ items. For this I need AutoTrash interface.
  Interface must be public to allow other modders use features of your mod I think.